### PR TITLE
ci: harden roboanimals workflow inputs

### DIFF
--- a/.github/workflows/roboanimals-workflow.yml
+++ b/.github/workflows/roboanimals-workflow.yml
@@ -147,9 +147,15 @@ jobs:
       uses: actions/github-script@v6.4.1
       if: ${{ inputs.from_pr == 'true' }}
       id: get-pr-title
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
       with:
         script: |
-          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number: ${{ inputs.pull_request_number }}});
+          const pull_number = Number.parseInt(process.env.PULL_REQUEST_NUMBER, 10);
+          if (!Number.isSafeInteger(pull_number)) {
+            throw new Error('Invalid pull request number');
+          }
+          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number});
           if (!pull.title) {
             return 'Empty Title 🤡';
           }
@@ -159,9 +165,15 @@ jobs:
       uses: actions/github-script@v6.4.1
       if: ${{ inputs.from_pr == 'true' }}
       id: get-pr-body
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
       with:
         script: |
-          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number: ${{ inputs.pull_request_number }}});
+          const pull_number = Number.parseInt(process.env.PULL_REQUEST_NUMBER, 10);
+          if (!Number.isSafeInteger(pull_number)) {
+            throw new Error('Invalid pull request number');
+          }
+          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number});
           if (!pull.body) {
             return 'Empty Description 🤡';
           }
@@ -172,9 +184,15 @@ jobs:
       uses: actions/github-script@v6.4.1
       if: ${{ inputs.from_pr == 'true' }}
       id: get-pr-author
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
       with:
         script: |
-          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number: ${{ inputs.pull_request_number }}});
+          const pull_number = Number.parseInt(process.env.PULL_REQUEST_NUMBER, 10);
+          if (!Number.isSafeInteger(pull_number)) {
+            throw new Error('Invalid pull request number');
+          }
+          const {data: pull} = await github.rest.pulls.get({...context.repo, pull_number});
           if (pull.user.login === null) {
             return 'Empty Author 🤡';
           }
@@ -184,15 +202,22 @@ jobs:
       uses: actions/github-script@v6.4.1
       if: ${{ inputs.check_reviews == 'true' }}
       id: get-pr
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        PR_AUTHOR: ${{ steps.get-pr-author.outputs.result }}
       with:
         script: |
+          const pull_number = Number.parseInt(process.env.PULL_REQUEST_NUMBER, 10);
+          if (!Number.isSafeInteger(pull_number)) {
+            throw new Error('Invalid pull request number');
+          }
           const { data: reviews } = await github.rest.pulls.listReviews({
             ...context.repo,
-            pull_number: ${{ inputs.pull_request_number }},
+            pull_number,
           })
 
           const approvals = reviews.filter(review => review.state == 'APPROVED')
-          const reviews_filtered = approvals.filter(review => review.user.login != ${{ steps.get-pr-author.outputs.result }})
+          const reviews_filtered = approvals.filter(review => review.user.login != process.env.PR_AUTHOR)
           core.info(`List of reviews:\n ${JSON.stringify(reviews_filtered)}`)
           return reviews_filtered.length
 
@@ -242,7 +267,7 @@ jobs:
         YRPC_API_KEY: ${{ secrets.YRPC_API_KEY }}
       run: |
         touch .env
-        echo YRPC_API_KEY=${{ secrets.YRPC_API_KEY }} >> .env
+        printf 'YRPC_API_KEY=%s\n' "$YRPC_API_KEY" >> .env
           
     - name: Add network config
       timeout-minutes: 1
@@ -277,9 +302,12 @@ jobs:
         BE: ${{ inputs.be }}
         SAFE_AUTH_TOKEN: ${{ secrets.SAFE_AUTH_TOKEN }}
         SAFE_TRANSACTION_SERVICE_API_KEY: ${{ secrets.SAFE_TRANSACTION_SERVICE_API_KEY }}
+        BROWNIE_FILE: ${{ inputs.file }}
+        BROWNIE_FUNCTION: ${{ inputs.fn }}
+        BROWNIE_NETWORK: ${{ inputs.network }}
       run: |
-        python3 -m multisig_ci brownie run -r ${{ inputs.file }} ${{ inputs.fn }} --network ${{ inputs.network }}-main-fork 1>output.txt 2>error.txt || EXIT_CODE=$?
-        echo "brownie-exit-code=$EXIT_CODE" >> $GITHUB_OUTPUT
+        python3 -m multisig_ci brownie run -r "$BROWNIE_FILE" "$BROWNIE_FUNCTION" --network "$BROWNIE_NETWORK-main-fork" 1>output.txt 2>error.txt || EXIT_CODE=$?
+        echo "brownie-exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
         echo "::group:: Output"
         cat output.txt
         echo "::endgroup::"
@@ -302,6 +330,8 @@ jobs:
 
     - name: Check failure
       id: failcheck
+      env:
+        BROWNIE_EXIT_CODE: ${{ steps.fn.outputs.brownie-exit-code }}
       run: |
         echo "::group:: Output"
         cat output.txt
@@ -309,7 +339,7 @@ jobs:
         echo "::group:: Error"
         cat error.txt
         echo "::endgroup::"
-        exit ${{ steps.fn.outputs.brownie-exit-code}}
+        exit "${BROWNIE_EXIT_CODE:-0}"
 
     - name: Nonce fail check, add comment
       if: inputs.send == 'true' && env.NONCE == ''
@@ -320,11 +350,14 @@ jobs:
           > Did not find nonce.txt. Did you run with send=true without actually posting the transaction at the end of your function? Use the @sign decorator above your function.
 
     - name: New TX Telegram Alert - MultiSig Chat
-      env:
-        TELEGRAM_MESSAGE: "Oof, ${{ steps.get-pr-author.outputs.result }} just tried to send a transaction without putting the @sign decorator above the function... Please join me in shaming this 🤡"
       if: inputs.send == 'true' && env.NONCE == ''
+      env:
+        PR_AUTHOR: ${{ steps.get-pr-author.outputs.result }}
+        TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+        GROUP_TELEGRAM_CHAT_ID: ${{ inputs.group_telegram_chat_id }}
       run: |
-        python3 -m multisig_ci send_and_pin_message ${{ secrets.TELEGRAM_TOKEN }} ${{ inputs.group_telegram_chat_id }}
+        export TELEGRAM_MESSAGE="Oof, $PR_AUTHOR just tried to send a transaction without putting the @sign decorator above the function... Please join me in shaming this 🤡"
+        python3 -m multisig_ci send_and_pin_message "$TELEGRAM_TOKEN" "$GROUP_TELEGRAM_CHAT_ID"
       continue-on-error: true
 
     - name: Nonce fail check
@@ -401,17 +434,29 @@ jobs:
     - name: Set PR url
       if: ${{ inputs.from_pr == 'true' }}
       id: pr-url
+      env:
+        REPOSITORY: ${{ github.repository }}
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
       run: |
-        echo "pr-url=https://github.com/${{github.repository}}/pull/${{ inputs.pull_request_number }}/files" >> $GITHUB_OUTPUT
+        echo "pr-url=https://github.com/$REPOSITORY/pull/$PULL_REQUEST_NUMBER/files" >> "$GITHUB_OUTPUT"
 
     - name: Create Telegram message - from PR
       if: ${{ inputs.send  == 'true' && inputs.from_pr == 'true' }}
+      env:
+        NETWORK: ${{ inputs.network }}
+        NONCE: ${{ env.NONCE }}
+        SAFE_LINK: ${{ env.SAFE_LINK }}
+        PR_TITLE: ${{ steps.get-pr-title.outputs.result }}
+        PR_AUTHOR: ${{ steps.get-pr-author.outputs.result }}
+        PR_BODY: ${{ steps.get-pr-body.outputs.result }}
+        PR_URL: ${{ steps.pr-url.outputs.pr-url }}
+        RUN_URL: ${{ steps.vars.outputs.run-url }}
       run: |
           TELEGRAM_MESSAGE=$(cat << EOF
-          ✍️ [${{ inputs.network}} #${{ env.NONCE }}](${{ env.SAFE_LINK }}) \`${{ steps.get-pr-title.outputs.result}}\`
-          Sender: ${{ steps.get-pr-author.outputs.result }}
-          Description: \`${{ steps.get-pr-body.outputs.result }}\`
-          Review [the code](${{ steps.pr-url.outputs.pr-url }}), verify [the output](${{ steps.vars.outputs.run-url }}), and [sign here](${{ env.SAFE_LINK }})
+          ✍️ [$NETWORK #$NONCE]($SAFE_LINK) \`$PR_TITLE\`
+          Sender: $PR_AUTHOR
+          Description: \`$PR_BODY\`
+          Review [the code]($PR_URL), verify [the output]($RUN_URL), and [sign here]($SAFE_LINK)
           EOF
           )
           echo "TELEGRAM_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -420,13 +465,22 @@ jobs:
 
     - name: Create Telegram message - automated
       if: ${{ inputs.send  == 'true' && inputs.from_pr == 'false' }}
+      env:
+        NETWORK: ${{ inputs.network }}
+        NONCE: ${{ env.NONCE }}
+        SAFE_LINK: ${{ env.SAFE_LINK }}
+        JOB_AUTHOR: ${{ inputs.job_author }}
+        JOB_DESCRIPTION: ${{ inputs.job_description }}
+        BROWNIE_FUNCTION: ${{ inputs.fn }}
+        BROWNIE_FILE: ${{ inputs.file }}
+        RUN_URL: ${{ steps.vars.outputs.run-url }}
       run: |
           TELEGRAM_MESSAGE=$(cat << EOF
-          ✍️ [${{ inputs.network}} #${{ env.NONCE }}](${{ env.SAFE_LINK }}) \`${{ steps.get-pr-title.outputs.result}}\`
-          Sender: ${{ inputs.job_author }} (via cronjob or manual trigger)
-          Description: ${{ inputs.job_description }}
-          Function ran: ${{ inputs.fn }} in ${{inputs.file}}.py
-          Verify [the output](${{ steps.vars.outputs.run-url }}), and [sign here](${{ env.SAFE_LINK }})
+          ✍️ [$NETWORK #$NONCE]($SAFE_LINK)
+          Sender: $JOB_AUTHOR (via cronjob or manual trigger)
+          Description: $JOB_DESCRIPTION
+          Function ran: $BROWNIE_FUNCTION in $BROWNIE_FILE.py
+          Verify [the output]($RUN_URL), and [sign here]($SAFE_LINK)
           EOF
           )
           echo "TELEGRAM_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -435,14 +489,20 @@ jobs:
 
     - name: New TX Telegram Alert - Robowoofy Alert Chat
       if: ${{ inputs.send == 'true' }}
+      env:
+        TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+        ANNOUNCEMENT_TELEGRAM_CHAT_ID: ${{ inputs.announcement_telegram_chat_id }}
       run: |
-        python3 -m multisig_ci send_and_pin_message ${{ secrets.TELEGRAM_TOKEN }} ${{ inputs.announcement_telegram_chat_id }}
+        python3 -m multisig_ci send_and_pin_message "$TELEGRAM_TOKEN" "$ANNOUNCEMENT_TELEGRAM_CHAT_ID"
       continue-on-error: true
 
     - name: New TX Telegram Alert - MultiSig Chat
       if: ${{ inputs.send == 'true' }}
+      env:
+        TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+        GROUP_TELEGRAM_CHAT_ID: ${{ inputs.group_telegram_chat_id }}
       run: |
-        python3 -m multisig_ci send_and_pin_message ${{ secrets.TELEGRAM_TOKEN }} ${{ inputs.group_telegram_chat_id }}
+        python3 -m multisig_ci send_and_pin_message "$TELEGRAM_TOKEN" "$GROUP_TELEGRAM_CHAT_ID"
       continue-on-error: true
 
     - name: Edit comment with full run message
@@ -465,13 +525,20 @@ jobs:
 
     - uses: actions/github-script@v6.4.1
       if: ${{ inputs.send  == 'true' && inputs.from_pr == 'true' }}
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        NONCE_LABEL: "${{ inputs.network }} #${{ env.NONCE }}"
       with:
         script: |
+          const issue_number = Number.parseInt(process.env.PULL_REQUEST_NUMBER, 10);
+          if (!Number.isSafeInteger(issue_number)) {
+            throw new Error('Invalid pull request number');
+          }
           github.rest.issues.addLabels({
-            issue_number: ${{ inputs.pull_request_number }},
+            issue_number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ['${{ inputs.network }} #${{ env.NONCE }}']
+            labels: [process.env.NONCE_LABEL]
           })
 
     - name: Delete PRs head branches


### PR DESCRIPTION
## Summary
- parse workflow PR numbers from environment variables inside github-script instead of interpolating them into JavaScript
- pass PR metadata and multisig workflow inputs through env vars before shell use
- quote Brownie, Telegram, and label command inputs
- avoid direct shell interpolation of secrets and reusable workflow inputs

## Validation
- ruby YAML parse over changed workflow
- uvx zizmor --offline --min-severity medium on changed workflow: targeted template-injection findings are cleared
- remaining zizmor findings are existing unpinned action refs and checkout credential persistence warning