### PR TITLE
Pin Robowoofy workflow actions

### DIFF
--- a/.github/workflows/roboanimals-workflow.yml
+++ b/.github/workflows/roboanimals-workflow.yml
@@ -252,7 +252,7 @@ jobs:
         echo $FOUNDRY_BIN_DIR >> $GITHUB_PATH
 
     - name: Set up python 3.10
-      uses: actions/setup-python@main
+      uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48
       with:
         python-version: '3.10'
 
@@ -559,7 +559,7 @@ jobs:
 
     - name: Telegram Alert On Infra Failure
       if: ${{ failure() && steps.failcheck.outcome == 'success' }}
-      uses: appleboy/telegram-action@master
+      uses: appleboy/telegram-action@37056891d444f558225b59f0d26b4b05c5e9828b
       with:
         disable_web_page_preview: true 
         to: ${{ inputs.failure_telegram_chat_id}}
@@ -570,7 +570,7 @@ jobs:
 
     - name: Telegram Alert On Brownie Timeout
       if: ${{ failure() && steps.timeout.outputs.brownie-timeout == 'true' }}
-      uses: appleboy/telegram-action@master
+      uses: appleboy/telegram-action@37056891d444f558225b59f0d26b4b05c5e9828b
       with:
         to: ${{ inputs.failure_telegram_chat_id }}
         token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
Pin moving actions in the Robowoofy reusable workflow.

Notes:
- Replaces `actions/setup-python@main` with an immutable commit.
- Replaces Telegram notification actions on `@master` with immutable commits.
- Reduces supply-chain exposure in a reusable workflow that receives private key, PAT, Telegram, and API secrets from callers.
- Validated touched workflows with PyYAML and git diff --check.